### PR TITLE
Generate test/ctags_stub.py with automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -106,7 +106,8 @@ AC_CONFIG_FILES([Makefile
 	libparser/Makefile
 	plugin-factory/Makefile
 	test/Makefile
+	test/ctags_stub.py
 	test/tests.sh
 ])
-AC_CONFIG_COMMANDS([tests_build], [chmod 755 test/tests.sh])
+AC_CONFIG_COMMANDS([tests_build], [chmod 755 test/tests.sh test/ctags_stub.py])
 AC_OUTPUT

--- a/test/ctags_stub.py.in
+++ b/test/ctags_stub.py.in
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!@PYTHON@
 #
 # Copyright (c) 2014
 #	Yoshitaro Makise


### PR DESCRIPTION
Even since 4632629 (Detect python executable path for tests too.) the
test suite failed to pass on systems where python3 is the default
executable for "python". This happened because test/ctags_stub.py would
still use the default of /usr/bin/python3, since environment variable
updates were only present during the config/make stages.

This changes test/ctags_stub.py to have an autogenerated shebang (#!)
line using automake. It resolves build issues by forcing use of the
python version chosen during configure regardless of the python
environment variable chosen at runtime.

---

Let me know if there's anything else you'd like to see with these changes.
I'm very appreciative of your work on #2 to help create clean builds across
systems. :+1: 
